### PR TITLE
Add endpoints

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,51 @@
 
 # integration-iron-io
 
+[Iron.io](http://iron.io) server-side integration for Segment.
+The current purpose of this integration is to funnel all Segment Data into a single queue for post processing. Queue can be configured in Poll or Push mode after integration is configured via the Iron.io Dashboard.
+
+**use cases:**
+- ETL operations
+- Playback of ordered Segment pipeline
+- Archive of Segment pipeline
+- Post worker processing
+
+
+## References
+[How To Contribute and Test](https://github.com/segmentio/integrations/blob/master/Contributing.md)
+
+### Iron.io Support
+General Support <support@iron.io>
+Stephen Nguyen <stephen@iron.io>, Integration Engineer
+
+## License
+
+(The MIT License)
+
+Copyright (c) 2014 Segment.io &lt;friends@segment.io&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+[![Build Status](https://circleci.com/gh/segmentio/integration-iron-io/tree/master.png?style=badge)](https://circleci.com/gh/segmentio/integration-iron-io/tree/master)
+
+# integration-iron-io
+
 Iron.io server-side integration for Segment.
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,12 +12,13 @@ var mapper = require('./mapper');
  */
 
 var Iron = module.exports = integration('Iron.io')
-  .endpoint('https://mq-aws-us-east-1.iron.io:443')
   .channels(['server', 'mobile', 'client'])
   .ensure('settings.projectId')
   .ensure('settings.token')
+  .ensure('settings.endpoint')
   .mapper(mapper)
   .retries(2);
+
 
 /**
  * Add methods.
@@ -40,7 +41,7 @@ Iron.prototype.page = sendRequest;
  */
 
 function sendRequest(payload, fn){
-  var url = fmt('/1/projects/%s/queues/segment/messages', this.settings.projectId);
+  var url = fmt('%s/1/projects/%s/queues/segment/messages', this.settings.endpoint , this.settings.projectId);
   return this
     .post(url)
     .query({ oauth: this.settings.token })

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ var Iron = module.exports = integration('Iron.io')
   .channels(['server', 'mobile', 'client'])
   .ensure('settings.projectId')
   .ensure('settings.token')
+  .ensure('settings.apiVersion')
   .ensure('settings.endpoint')
   .mapper(mapper)
   .retries(2);
@@ -41,7 +42,7 @@ Iron.prototype.page = sendRequest;
  */
 
 function sendRequest(payload, fn){
-  var url = fmt('%s/1/projects/%s/queues/segment/messages', this.settings.endpoint , this.settings.projectId);
+  var url = fmt('%s/%s/projects/%s/queues/segment/messages', this.settings.endpoint , this.settings.apiVersion, this.settings.projectId);
   return this
     .post(url)
     .query({ oauth: this.settings.token })

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,8 @@ describe('Iron IO', function(){
   beforeEach(function(){
     settings = {
       projectId: '534bf145c629690009000039',
-      token: 'uwa4ZE1ykvC5aHgsrkC2HAPJw2o'
+      token: 'uwa4ZE1ykvC5aHgsrkC2HAPJw2o',
+      endpoint: 'https://mq-aws-us-east-1.iron.io:443'
     };
     iron = new IronIO(settings);
     test = Test(iron, __dirname);
@@ -29,10 +30,10 @@ describe('Iron IO', function(){
   it('should have the correct settings', function(){
     test
       .name('Iron.io')
-      .endpoint('https://mq-aws-us-east-1.iron.io:443')
       .channels(['server', 'mobile', 'client'])
       .ensure('settings.projectId')
-      .ensure('settings.token');
+      .ensure('settings.token')
+      .ensure('settings.endpoint');
   });
 
   describe('.validate()', function(){
@@ -42,6 +43,10 @@ describe('Iron IO', function(){
     });
 
     it('should be invalid when .projectId is missing', function(){
+      delete settings.projectId;
+      test.invalid({}, settings);
+    });
+    it('should be invalid when .endpoint is missing', function(){
       delete settings.projectId;
       test.invalid({}, settings);
     });

--- a/test/index.js
+++ b/test/index.js
@@ -7,17 +7,19 @@ var should = require('should');
 var assert = require('assert');
 var IronIO = require('..');
 
-describe('Iron IO', function(){
+describe('Iron IO v2', function(){
   var settings;
   var iron;
   var test;
   var error;
 
   beforeEach(function(){
+    //
     settings = {
       projectId: '534bf145c629690009000039',
       token: 'uwa4ZE1ykvC5aHgsrkC2HAPJw2o',
-      endpoint: 'https://mq-aws-us-east-1.iron.io:443'
+      endpoint: 'https://mq-aws-us-east-1.iron.io:443',
+      apiVersion: '1'
     };
     iron = new IronIO(settings);
     test = Test(iron, __dirname);
@@ -38,7 +40,7 @@ describe('Iron IO', function(){
 
   describe('.validate()', function(){
     it('should be invalid when .token is missing', function(){
-      delete settings.projectId;
+      delete settings.token;
       test.invalid({}, settings);
     });
 
@@ -46,12 +48,207 @@ describe('Iron IO', function(){
       delete settings.projectId;
       test.invalid({}, settings);
     });
+
     it('should be invalid when .endpoint is missing', function(){
+      delete settings.endpoint;
+      test.invalid({}, settings);
+    });
+
+    it('should be invalid when .endpoint is missing', function(){
+      delete settings.apiVersion;
+      test.invalid({}, settings);
+    });
+
+    it('should be vaild when both .projectId, .token, endpoint, and api version are given', function(){
+      test.valid({}, settings);
+    });
+  });
+
+  describe('mapper', function(){
+    describe('identify', function(){
+      it('should map basic identify', function(){
+        test.maps('identify-basic');
+      });
+    });
+
+    describe('screen', function(){
+      it('should map basic screen', function(){
+        test.maps('screen-basic');
+      });
+    });
+
+    describe('alias', function(){
+      it('should map basic alias', function(){
+        test.maps('alias-basic');
+      });
+    });
+
+    describe('track', function(){
+      it('should map basic track', function(){
+        test.maps('track-basic');
+      });
+    });
+
+    describe('page', function(){
+      it('should map basic page', function(){
+        test.maps('page-basic');
+      });
+    });
+  });
+
+  describe('.track()', function(){
+    it('should track correctly', function(done){
+      var msg = helpers.track();
+      test
+        .set(settings)
+        .track(msg)
+        .sends(message(msg))
+        .expects(200, done);
+    });
+
+    it('should error on invalid creds', function(done){
+      test
+        .set({ token: 'x' })
+        .track({})
+        .error(error, done);
+    });
+  });
+
+  describe('.identify()', function(){
+    it('should be able to identify correctly', function(done){
+      var msg = helpers.identify();
+      test
+        .set(settings)
+        .identify(msg)
+        .sends(message(msg))
+        .expects(200, done);
+    });
+
+    it('should error on invalid creds', function(done){
+      test
+        .set({ token: 'x' })
+        .identify({})
+        .error(error, done);
+    });
+  });
+
+  describe('.screen()', function(){
+    it('should be able to screen correctly', function(done){
+      var msg = helpers.screen();
+      test
+        .set(settings)
+        .screen(msg)
+        .sends(message(msg))
+        .expects(200, done);
+    });
+
+    it('should error on invalid creds', function(done){
+      test
+        .set({ token: 'x' })
+        .screen({})
+        .error(error, done);
+    });
+  });
+
+  describe('.page()', function(){
+    it('should be able to page correctly', function(done){
+      var msg = helpers.page();
+      test
+        .set(settings)
+        .page(msg)
+        .sends(message(msg))
+        .expects(200, done);
+    });
+
+    it('should error on invalid creds', function(done){
+      test
+        .set({ token: 'x' })
+        .page({})
+        .error(error, done);
+    });
+  });
+
+  describe('.alias()', function(){
+    it('should be able to alias correctly', function(done){
+      var msg = helpers.alias();
+      test
+        .set(settings)
+        .alias(msg)
+        .sends(message(msg))
+        .expects(200, done);
+    });
+
+    it('should error on invalid creds', function(done){
+      test
+        .set({ token: 'x' })
+        .alias({})
+        .error(error, done);
+    });
+  });
+
+  function message(msg){
+    return {
+      messages: [
+        { body: JSON.stringify(msg.json()) }
+      ]
+    };
+  }
+});
+
+
+
+describe('Iron IO v3', function(){
+  var settings;
+  var iron;
+  var test;
+  var error;
+
+  beforeEach(function(){
+    settings = {
+      projectId: '54c96901ccd9880007000005',
+      token: 'ao3ab3hkFkiP270d4rTf',
+      endpoint: 'http://mq-v3-aws-us-east-1.iron.io',
+      apiVersion: '3'
+    };
+    iron = new IronIO(settings);
+    test = Test(iron, __dirname);
+  });
+
+  beforeEach(function(){
+    error = fmt('cannot POST /3/projects/%s/queues/segment/messages?oauth=x (401)', settings.projectId);
+  })
+
+  it('should have the correct settings', function(){
+    test
+      .name('Iron.io')
+      .channels(['server', 'mobile', 'client'])
+      .ensure('settings.projectId')
+      .ensure('settings.token')
+      .ensure('settings.endpoint');
+  });
+
+  describe('.validate()', function(){
+    it('should be invalid when .token is missing', function(){
+      delete settings.token;
+      test.invalid({}, settings);
+    });
+
+    it('should be invalid when .projectId is missing', function(){
       delete settings.projectId;
       test.invalid({}, settings);
     });
 
-    it('should be vaild when both .projectId and .token are given', function(){
+    it('should be invalid when .endpoint is missing', function(){
+      delete settings.endpoint;
+      test.invalid({}, settings);
+    });
+
+    it('should be invalid when .endpoint is missing', function(){
+      delete settings.apiVersion;
+      test.invalid({}, settings);
+    });
+
+    it('should be vaild when both .projectId, .token, endpoint, and api version are given', function(){
       test.valid({}, settings);
     });
   });


### PR DESCRIPTION
Hello guys,

There are a number of options that we needed to add to give your users for flexibility with our service

- endpoint
- api version

Ideally we would like users to default to and change these later if we can add a select dropdown for these options via the Segment UI that would be most helpful for your users.

```js
apiVersion: "1"
endpoint : "mq-aws-us-east-1.iron.io"
```

![integrations - ironioiron-production 2015-01-28 15-29-58](https://cloud.githubusercontent.com/assets/1712162/5949511/3e59cc2e-a703-11e4-9571-e41e88b228f6.jpg)

![selfie-1](http://i.imgur.com/alQcYER.gif)

stephen@iron.io